### PR TITLE
Invoke the onScroll method passed in through props

### DIFF
--- a/src/component/VerticalViewPager.js
+++ b/src/component/VerticalViewPager.js
@@ -83,6 +83,7 @@ class VerticalViewPager extends Component {
         if (!this._scrolling) {
             this._startEnableScrollTimer();
         }
+        _.invoke(this.props, 'onScroll', e);
     }
 
     _setStartOffset(startOffset) {


### PR DESCRIPTION
I noticed that the onScroll hook was not being exposed. So adding a hook into the onScroll method of the scroll view.